### PR TITLE
bugfix in llm setup

### DIFF
--- a/exo/inference/torch/model/hf.py
+++ b/exo/inference/torch/model/hf.py
@@ -92,17 +92,18 @@ class ShardedHuggingFaceModel:
         # this is needed because shard downloader just
         # appends and not redownloads the file
         os.remove(self.model_safetensors_path)
+
+        self.llm_model = AutoModelForCausalLM.from_config(self.llm_model_config).to(self.device)
+        self.model = self.llm_model.model.to(self.device)
       else:
-        self.llm_model_config = AutoConfig.from_pretrained(
+        self.llm_model = AutoModelForCausalLM.from_pretrained(
           pretrained_model_name_or_path=self.local_model_path,
           torch_dtype=self.dtype,
           device_map=self.device_map,
           offload_buffers=self.offload_buffers
         )
-
-      self.llm_model = AutoModelForCausalLM.from_config(self.llm_model_config).to(self.device)
-
-      self.model = self.llm_model.model.to(self.device)
+        self.model = self.llm_model.model
+      
     except Exception as err:
       print(f"error loading and splitting model: {err}")
       raise


### PR DESCRIPTION
The change in [this commit](https://github.com/exo-explore/exo/pull/139/commits/aacdeb595e8a47e9d8a0d45e8e3ac84c92efa4e5) started making my transformers act funky:

![failure_screenshot](https://github.com/user-attachments/assets/8f430b18-ec76-4914-b444-8a22fa64d815)

I partially reverted the changes so that the `else` portion works the same as before.

**Setup:**
- Windows - WSL Ubuntu with no CUDA/GPU.
- Single node
- command `exo --inference-engine torch --run-model llama-3.2-1b --prompt "Finish this sentence: never gonna give you up..."`

After reverting the `else`, I get this (a larger model would do a bit better, but it looks like it's processing properly):
![image](https://github.com/user-attachments/assets/4be9f3a8-1304-4414-923d-3c8c9344c190)

